### PR TITLE
Make styles !important.

### DIFF
--- a/src/objectFitPolyfill.basic.js
+++ b/src/objectFitPolyfill.basic.js
@@ -1,5 +1,5 @@
 /*----------------------------------------
- * objectFitPolyfill 2.0
+ * objectFitPolyfill 2.1
  *
  * Basic, no-frills version -
  * Defaults to object-fit: cover and object-position: 50% 50%
@@ -42,18 +42,18 @@
     var display = styles.getPropertyValue("display");
 
     if (!position || position === "static") {
-      $container.style.position = "relative";
+      $media.style.setProperty( 'position', 'relative', 'important' );
     }
     if (overflow !== "hidden") {
-      $container.style.overflow = "hidden";
+      $media.style.setProperty( 'overflow', 'hidden', 'important' );
     }
     // Guesstimating that people want the parent to act like full width/height wrapper here.
     // Mostly attempts to target <picture> elements, which default to inline.
     if (!display || display === "inline") {
-      $container.style.display = "block";
+      $media.style.setProperty( 'display', 'block', 'important' );
     }
     if ($container.clientHeight === 0) {
-      $container.style.height = "100%";
+      $media.style.setProperty( 'height', '100%', 'important' );
     }
 
     $container.className = $container.className + ' object-fit-polyfill';
@@ -79,7 +79,7 @@
       var constraint = styles.getPropertyValue(property);
 
       if (constraint !== constraints[property]) {
-        $media.style[property] = constraints[property];
+        $media.style.setProperty( property, constraints[property], 'important' );
       }
     }
   };
@@ -98,25 +98,25 @@
     checkMediaConstraints($media);
 
     // Mathematically figure out which side needs covering, and add CSS positioning & centering
-    $media.style.position = "absolute";
-    $media.style.height = "100%";
-    $media.style.width = "auto";
+    $media.style.setProperty( 'position', 'absolute', 'important' );
+    $media.style.setProperty( 'height',   '100%',     'important' );
+    $media.style.setProperty( 'width',    'auto',     'important' );
 
     if (
       $media.clientWidth > $container.clientWidth
     ) {
-      $media.style.top = "0";
-      $media.style.marginTop = "0";
-      $media.style.left = "50%";
-      $media.style.marginLeft = ($media.clientWidth / -2) + "px";
+      $media.style.setProperty( 'top',       '0',   'important' );
+      $media.style.setProperty( 'marginTop', '0',   'important' );
+      $media.style.setProperty( 'left',      '50%', 'important' );
+      $media.style.setProperty( 'marginLeft', ($media.clientWidth / -2) + 'px', 'important' );
     }
     else {
-      $media.style.width = "100%";
-      $media.style.height = "auto";
-      $media.style.left = "0";
-      $media.style.marginLeft = "0";
-      $media.style.top = "50%";
-      $media.style.marginTop = ($media.clientHeight / -2) + "px";
+      $media.style.setProperty( 'width',      '100%', 'important' );
+      $media.style.setProperty( 'height',     'auto', 'important' );
+      $media.style.setProperty( 'left',       '0',    'important' );
+      $media.style.setProperty( 'marginLeft', '0',    'important' );
+      $media.style.setProperty( 'top',        '50%',  'important' );
+      $media.style.setProperty( 'marginTop',  ($media.clientHeight / -2) + 'px', 'important' );
     }
   };
 

--- a/src/objectFitPolyfill.basic.js
+++ b/src/objectFitPolyfill.basic.js
@@ -105,18 +105,18 @@
     if (
       $media.clientWidth > $container.clientWidth
     ) {
-      $media.style.setProperty( 'top',       '0',   'important' );
-      $media.style.setProperty( 'marginTop', '0',   'important' );
-      $media.style.setProperty( 'left',      '50%', 'important' );
-      $media.style.setProperty( 'marginLeft', ($media.clientWidth / -2) + 'px', 'important' );
+      $media.style.setProperty( 'top',        '0',   'important' );
+      $media.style.setProperty( 'margin-top', '0',   'important' );
+      $media.style.setProperty( 'left',       '50%', 'important' );
+      $media.style.setProperty( 'margin-left', ($media.clientWidth / -2) + 'px', 'important' );
     }
     else {
-      $media.style.setProperty( 'width',      '100%', 'important' );
-      $media.style.setProperty( 'height',     'auto', 'important' );
-      $media.style.setProperty( 'left',       '0',    'important' );
-      $media.style.setProperty( 'marginLeft', '0',    'important' );
-      $media.style.setProperty( 'top',        '50%',  'important' );
-      $media.style.setProperty( 'marginTop',  ($media.clientHeight / -2) + 'px', 'important' );
+      $media.style.setProperty( 'width',       '100%', 'important' );
+      $media.style.setProperty( 'height',      'auto', 'important' );
+      $media.style.setProperty( 'left',        '0',    'important' );
+      $media.style.setProperty( 'margin-left', '0',    'important' );
+      $media.style.setProperty( 'top',         '50%',  'important' );
+      $media.style.setProperty( 'margin-top',  ($media.clientHeight / -2) + 'px', 'important' );
     }
   };
 


### PR DESCRIPTION
I would be glad if you would pull this, otherwise I have to maintain my own copy.

I am aware that `!important` styles are bad practice but the thing is I am dealing with 3rd party code so my CSS needs to have !important rules in it to make sure elements are styled the way I define them.

With the native native browsers `object-fit` there is no problem because as object fit does not work like this polyfill, meaning it does not calculate and does this with margin and stuff so this values are ignored even if set with !important. One rule where this polyfill fails is `margin: 0 !important;` for example. I rather tried to make everything stick because I think when using this polyfill one really wants it to apply its styles no matter what. I think its not a bad Idea to do this even for other users so !important styles do never get into the way.

`setProperty` is IE9+ so it would fit.

This is currently untested and I only done this to the basic version only to see what you say.
