### PR TITLE
Added objectFitPolyfill to window

### DIFF
--- a/src/objectFitPolyfill.basic.js
+++ b/src/objectFitPolyfill.basic.js
@@ -168,4 +168,6 @@ if (typeof objectFitPolyfill === "function") {
   window.addEventListener("resize", function() {
     objectFitPolyfill();
   });
+  
+  window.objectFitPolyfill = objectFitPolyfill;
 }


### PR DESCRIPTION
Once `objectFitPolyfill` is added to `window`, it's more configurable when it gets called without having to modify 3rd party source code to add this in manually.