### PR TITLE
Use auto for resetting position

### DIFF
--- a/src/objectFitPolyfill.basic.js
+++ b/src/objectFitPolyfill.basic.js
@@ -94,7 +94,7 @@
     if (
       $media.clientWidth > $container.clientWidth
     ) {
-      $media.style.top = "0";
+      $media.style.top = "auto";
       $media.style.marginTop = "0";
       $media.style.left = "50%";
       $media.style.marginLeft = ($media.clientWidth / -2) + "px";
@@ -102,7 +102,7 @@
     else {
       $media.style.width = "100%";
       $media.style.height = "auto";
-      $media.style.left = "0";
+      $media.style.left = "auto";
       $media.style.marginLeft = "0";
       $media.style.top = "50%";
       $media.style.marginTop = ($media.clientHeight / -2) + "px";

--- a/src/objectFitPolyfill.js
+++ b/src/objectFitPolyfill.js
@@ -188,14 +188,14 @@
       fit === "cover"   && $media.clientWidth > $container.clientWidth ||
       fit === "contain" && $media.clientWidth < $container.clientWidth
     ) {
-      $media.style.top = "0";
+      $media.style.top = "auto";
       $media.style.marginTop = "0";
       setPosition("x", $media, position);
     }
     else if (fit !== "scale-down") {
       $media.style.width = "100%";
       $media.style.height = "auto";
-      $media.style.left = "0";
+      $media.style.left = "auto";
       $media.style.marginLeft = "0";
       setPosition("y", $media, position);
     }


### PR DESCRIPTION
Currently this script uses "0" to reset the top and left positions when setting the axis. This can result in both left and right being set on the $media with a width 100%. This causes some weirdness when working resizing the browser.

This commit sets the left and top to auto allowing the positioning to work correctly.