### PR TITLE
Unset position and margin of sides furthest from position.

### DIFF
--- a/src/objectFitPolyfill.js
+++ b/src/objectFitPolyfill.js
@@ -122,11 +122,15 @@
       if (position < 50) {
         $media.style[start] = position + "%";
         $media.style["margin-" + start] = side * (position / -100) + "px";
+        $media.style[end] = 'auto';
+        $media.style["margin-" + end] = "0px";
       }
       else {
         position = 100 - position;
         $media.style[end] = position + "%";
         $media.style["margin-" + end] = side * (position / -100) + "px";
+        $media.style[start] = 'auto';
+        $media.style["margin-" + start] = "0px";
       }
 
       return;


### PR DESCRIPTION
We we're having problems using 'cover' mode with right aligned images. The image would always appear aligned left, (instead of right) as the script was setting left:0, right:0 and width: 100%

This should hopefully correct the problem by resetting the opposing position parameters, and letting and ensure a single position/margin/size combo does the work.

I've tested this with 'cover' and 'contain' modes.
