### PR TITLE
return if the page is being rendered on the server

### DIFF
--- a/src/objectFitPolyfill.basic.js
+++ b/src/objectFitPolyfill.basic.js
@@ -13,6 +13,11 @@
 (function(){
   "use strict";
 
+  // if the page is being rendered on the server, don't continue
+  if (typeof window === "undefined") {
+      return;
+  }
+
   // If the browser does support object-fit, we don't need to continue
   if ("objectFit" in document.documentElement.style !== false) {
     window.objectFitPolyfill = function() { return false };

--- a/src/objectFitPolyfill.js
+++ b/src/objectFitPolyfill.js
@@ -10,6 +10,11 @@
 (function(){
   "use strict";
 
+  // if the page is being rendered on the server, don't continue
+  if (typeof window === "undefined") {
+      return;
+  }
+
   // If the browser does support object-fit, we don't need to continue
   if ("objectFit" in document.documentElement.style !== false) {
     window.objectFitPolyfill = function() { return false };


### PR DESCRIPTION
This is the only polyfill I could find that seems to work properly with videos on IE and Edge, so than you so much for creating this @constancecchen! 

I am trying to use this polyfill with a React app, and this breaks when doing server side rendering and document is not defined. 

I just check to see if `window` is undefined and return, which allows us to import objectFitPolyfill at the top of the file, and not have to require it in `componentDidMount`. Please let me know if you think this a good approach to handle this situation.

cc @Eschon 