### PR TITLE
Upload non-minified version to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A Javascript polyfill for browsers that don't support the object-fit CSS property",
   "main": "dist/objectFitPolyfill.min.js",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "keywords": [
     "object-fit",


### PR DESCRIPTION
I found this polyfill when working on [WordPress/gutenberg](https://github.com/wordpress/gutenberg/). However, [plugins must include a (mostly) human readable version of the code](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#4-code-must-be-mostly-human-readable). Uploading the src folder to npm would allow us to use it.